### PR TITLE
Remove deprecated ReflectionType::__toString call

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "email": "php@graphaware.com"
     }],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "doctrine/annotations": "^1.2",
         "doctrine/collections": "^1.3",
         "doctrine/common": "^2.6",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "email": "php@graphaware.com"
     }],
     "require": {
-        "php": "^7.1",
+        "php": "^7.4",
         "doctrine/annotations": "^1.2",
         "doctrine/collections": "^1.3",
         "doctrine/common": "^2.6",


### PR DESCRIPTION
Remove notices like

`php.INFO: Deprecated: Function ReflectionType::__toString() is deprecated {"exception":"[object] (ErrorException(code: 0): Deprecated: Function ReflectionType::__toString() is deprecated at /application/vendor/autoprotect-group/neo4j-php-ogm/src/Proxy/ProxyFactory.php:163`